### PR TITLE
Feature: Private API Gateway

### DIFF
--- a/modules/apigw/main.tf
+++ b/modules/apigw/main.tf
@@ -4,6 +4,13 @@ resource "aws_api_gateway_rest_api" "api" {
   description              = "API for ${var.name}"
   binary_media_types       = var.binary_type
   minimum_compression_size = var.minimum_compression_size
+
+  policy = var.endpoint_type == "PRIVATE" ? data.aws_iam_policy_document.private.json : null
+
+  endpoint_configuration {
+    types = [var.endpoint_type]
+    vpc_endpoint_ids = var.endpoint_type == "PRIVATE" ? [var.vpc_private_endpoint_id] : null
+  }
 }
 
 resource "aws_api_gateway_resource" "proxy" {

--- a/modules/apigw/policy.tf
+++ b/modules/apigw/policy.tf
@@ -1,0 +1,43 @@
+data "aws_iam_policy_document" "private" {
+  statement {
+    effect = "Deny"
+
+    principals {
+      type = "AWS" 
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "execute-api:Invoke"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    condition {
+      test = "StringNotEquals"
+      variable = "aws:sourceVpce"
+      values = [
+        var.vpc_private_endpoint_id
+      ]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+
+    principals {
+      type = "AWS" 
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "execute-api:Invoke"
+    ]
+
+    resources = [
+      "*"
+    ]
+  }
+}

--- a/modules/apigw/variables.tf
+++ b/modules/apigw/variables.tf
@@ -29,3 +29,15 @@ variable "lambda_arn" {
 variable "lambda_arn_invoke" {
   description = "The lambda invoke uri"
 }
+
+variable "endpoint_type" {
+  type = string
+  description = "The endpoint type supported by the RestApi: [https://www.terraform.io/docs/providers/aws/r/api_gateway_rest_api.html#types]"
+  default = "EDGE"
+}
+
+variable "vpc_private_endpoint_id" {
+  type = string
+  description = "The VPC endpoint id used to connect to a Private API Gateway"
+  default = null
+}


### PR DESCRIPTION
### Overview
Added new configuration, inputs and outputs to allow us to create a Private API Gateway. 

### Proposed changes
- Add an IAM policy to be used when a private API is specified
  - At the moment, I can't update the policy to operate on specific resources because of the below reasons,  so I have instead defined it to operate on all resource paths (which should be OK anyways)
    - Private API Gateway requires a 'policy' input, but I want to use this api gateway's ARN in the policy, but I can only get that once it is deployed, so there's a cyclic dependency here. 
    - There's an open [issue](https://github.com/terraform-providers/terraform-provider-aws/issues/5549) that might see changes introduced to fix this.
- Add configuration, inputs and outputs. 

### Notes
- This works in DEV, I'm able to create and connect to the private API Gateway

### Tickets
- [SL-696]

### Checklist
- [x] Clear title such as "Feature: ..." or "Fix: ..." or other
- [x] Clear and descriptive overview explaining why this change is needed
- [x] List of changes proposed in this pull request (short bullet points)
- [x] List of related changes such as external diffs, related releases or other
- [x] Additional notes that would help the reviewers approve more quickly and with confidence
